### PR TITLE
changed fragment to show 404 when discussion tab is clicked

### DIFF
--- a/lms/djangoapps/discussion/plugins.py
+++ b/lms/djangoapps/discussion/plugins.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_noop
 
 import lms.djangoapps.discussion.django_comment_client.utils as utils
 from lms.djangoapps.courseware.tabs import EnrolledTab
-from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE
+from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE, DISCUSSION_DISABLED
 from openedx.core.djangoapps.discussions.url_helpers import get_discussions_mfe_url
 from openedx.features.lti_course_tab.tab import DiscussionLtiCourseTab
 from xmodule.tabs import TabFragmentViewMixin  # lint-amnesty, pylint: disable=wrong-import-order
@@ -45,6 +45,8 @@ class DiscussionTab(TabFragmentViewMixin, EnrolledTab):
 
     @classmethod
     def is_enabled(cls, course, user=None):
+        if DISCUSSION_DISABLED.is_enabled(course.id):
+            return False
         if not super().is_enabled(course, user):
             return False
         # Disable the regular discussion tab if LTI-based external Discussion forum is enabled

--- a/lms/djangoapps/discussion/toggles.py
+++ b/lms/djangoapps/discussion/toggles.py
@@ -13,3 +13,4 @@ WAFFLE_FLAG_NAMESPACE = "discussions"
 # .. toggle_creation_date: 2021-11-05
 # .. toggle_target_removal_date: 2022-03-05
 ENABLE_DISCUSSIONS_MFE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_discussions_mfe', __name__)
+DISCUSSION_DISABLED = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'disable_discussion_tab', __name__)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -768,6 +768,7 @@ class DiscussionBoardFragmentView(EdxFragmentView):
             else:
                 html = render_to_string('discussion/discussion_board_fragment.html', context)
 
+            html = "Error 404: NOT Found"
             fragment = Fragment(html)
             self.add_fragment_resource_urls(fragment)
             inline_js = render_to_string('discussion/discussion_board_js.template', context)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -45,7 +45,7 @@ from lms.djangoapps.discussion.django_comment_client.utils import (
     strip_none,
 )
 from lms.djangoapps.discussion.exceptions import TeamDiscussionHiddenFromUserException
-from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE
+from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE, DISCUSSION_DISABLED
 from lms.djangoapps.experiments.utils import get_experiment_user_metadata_context
 from lms.djangoapps.teams import api as team_api
 from openedx.core.djangoapps.discussions.url_helpers import get_discussions_mfe_url
@@ -762,13 +762,15 @@ class DiscussionBoardFragmentView(EdxFragmentView):
             context.update({
                 'course_expiration_fragment': course_expiration_fragment,
             })
-            if profile_page_context:
+            
+            if DISCUSSION_DISABLED.is_enabled(course_key):
+                html = "Error 404: NOT Found"
+            elif profile_page_context:
                 # EDUCATOR-2119: styles are hard to reconcile if the profile page isn't also a fragment
                 html = render_to_string('discussion/discussion_profile_page.html', profile_page_context)
             else:
                 html = render_to_string('discussion/discussion_board_fragment.html', context)
 
-            html = "Error 404: NOT Found"
             fragment = Fragment(html)
             self.add_fragment_resource_urls(fragment)
             inline_js = render_to_string('discussion/discussion_board_js.template', context)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -764,7 +764,7 @@ class DiscussionBoardFragmentView(EdxFragmentView):
             })
             
             if DISCUSSION_DISABLED.is_enabled(course_key):
-                html = "Error 404: NOT Found"
+                raise Http404
             elif profile_page_context:
                 # EDUCATOR-2119: styles are hard to reconcile if the profile page isn't also a fragment
                 html = render_to_string('discussion/discussion_profile_page.html', profile_page_context)


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Show 404 when discussion tab is clicked

fragment body in view has been changed to show "Error 404: NOT Found" instead of showing the template code of fragment body.